### PR TITLE
Fix format of datalayer

### DIFF
--- a/class-plugin.php
+++ b/class-plugin.php
@@ -111,7 +111,7 @@ class Plugin {
 
 		if ( ! empty( $data ) ) {
 			return sprintf( '<script>var dataLayer = %s;</script>',
-				json_encode( $data )
+				json_encode( array( $data ) )
 			);
 		}
 


### PR DESCRIPTION
I'm getting an error - something like `Object w[l] doesn't support method 'push'`

* `w[l]` is `window.datalayer`.
* But Datalayer is an object so you can't push to it. I think this must be wrong.
* Looking [at the docs](https://developers.google.com/tag-manager/devguide) I think it should be an array.

This fixes the error. I'm not that knowlegable about GTM though so this might not be the issue.