### PR TITLE
Add User Report Service support. 

### DIFF
--- a/class-plugin.php
+++ b/class-plugin.php
@@ -22,15 +22,32 @@ class Plugin {
 	public function action_admin_init() {
 
 		// add settings section
-		add_settings_section( 'hm_gtm', esc_html__( 'Google Tag Manager', 'hm_gtm' ), array( $this, 'settings_section' ), 'general' );
+		add_settings_section( 'hm_gtm', esc_html__( 'Google Tag Manager', 'hm_gtm' ), array(
+			$this,
+			'settings_section'
+		), 'general' );
+
+		add_settings_field( 'hm_user_report_id_field', esc_html__( 'User report ID', 'hm_gtm' ), array(
+			$this,
+			'text_settings_field'
+		), 'general', 'hm_gtm', array(
+			'value'       => get_option( 'hm_user_report_id', '' ),
+			'name'        => 'hm_user_report_id',
+			'description' => esc_html__( 'Enter your User Report ID eg. 2fe19bec-4466-4294-ad6a-5db210106d47', 'hm_gtm' ),
+			'class'       => 'regular-text'
+		) );
 
 		// add settings field
-		add_settings_field( 'hm_gtm_id_field', esc_html__( 'Container ID', 'hm_gtm' ), array( $this, 'text_settings_field' ), 'general', 'hm_gtm', array(
+		add_settings_field( 'hm_gtm_id_field', esc_html__( 'Container ID', 'hm_gtm' ), array(
+			$this,
+			'text_settings_field'
+		), 'general', 'hm_gtm', array(
 			'value'       => get_option( 'hm_gtm_id', '' ),
 			'name'        => 'hm_gtm_id',
 			'description' => esc_html__( 'Enter your container ID eg. GTM-123ABC', 'hm_gtm' )
 		) );
 
+		register_setting( 'general', 'hm_user_report_id', 'sanitize_text_field' );
 		register_setting( 'general', 'hm_gtm_id', 'sanitize_text_field' );
 
 	}
@@ -40,16 +57,19 @@ class Plugin {
 	}
 
 	public function text_settings_field( $args ) {
+
 		$args = wp_parse_args( $args, array(
 			'name'        => '',
 			'value'       => '',
-			'description' => ''
+			'description' => '',
+			'class'       => ''
 		) );
 
-		printf( '<input type="text" id="%1$s" name="%1$s" value="%2$s" />%3$s',
+		printf( '<input type="text" id="%1$s" class="%4$s" name="%1$s" value="%2$s" />%3$s',
 			esc_attr( $args['name'] ),
 			esc_attr( $args['value'] ),
-			$args['description'] ? '<br /> <span class="description">' . esc_html( $args['description'] ) . '</span>' : ''
+			$args['description'] ? '<br /> <span class="description">' . esc_html( $args['description'] ) . '</span>' : '',
+			esc_attr( $args['class'] )
 		);
 	}
 

--- a/hm-gtm.php
+++ b/hm-gtm.php
@@ -18,14 +18,28 @@ add_action( 'plugins_loaded', array( 'HM_GTM\Plugin', 'get_instance' ) );
  * Output the gtm tag, place this immediately after the opening <body> tag
  *
  * @param bool $echo
+ * @param bool $user_report
+ *
  * @return string
  */
-function tag( $echo = true ) {
+function tag( $echo = true, $user_report = true ) {
 
 	$id = get_option( 'hm_gtm_id', false );
 
 	if ( ! $id ) {
 		return '';
+	}
+
+	if ( $user_report ) {
+
+		add_filter( 'hm_gtm_data_layer', function ( $data ) {
+			$user_report_id = get_option( 'hm_user_report_id', false );
+			if ( ! empty ( $user_report_id ) ) {
+				$data['user_report_id'] = $user_report_id;
+			}
+
+			return $data;
+		} );
 	}
 
 	$tag = sprintf( '


### PR DESCRIPTION
@sanchothefat 
Add setting field for `User Report Id` within `Google Tag Manager` group. Add a parameter to `tag` function whether use the User Report or not.

For using the `user_report_id` variable must be declared in GMT account. And inserted into provided by UserReport javascript snippet.