### PR TITLE
Moving the container to wp_head action and update GTM script

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,7 @@ Google Tag Manager template tags and settings tool
 
 Once the plugin is installed and activated there are 2 steps:
 
-1. Add the template tag `HM_GTM\tag()` immediately after the opening `<body>` tag
-2. On the general settings page in admin add your container ID eg. `GTM-123ABC`
-
-## Example code
-
-```php
-<?php if ( function_exists( 'HM_GTM\tag' ) ) { HM_GTM\tag(); } ?>
-```
+1. On the general settings page in admin add your container ID eg. `GTM-123ABC`
 
 ## Data Layer
 

--- a/README.md
+++ b/README.md
@@ -4,15 +4,24 @@ Google Tag Manager template tags and settings tool
 
 ## Usage
 
-Once the plugin is installed and activated there are 2 steps:
+Once the plugin is installed and activated there are 2 places you can configure:
 
 1. On the general settings page in admin add your container ID eg. `GTM-123ABC`
+2. For multisite install you can set a network wide container ID on the network settings screen
+
+### No script fallback
+
+If you wish to support the fallback iframe for devices without javascript add the following code just after the opening `<body>` tag in your theme:
+
+```php
+<?php do_action( 'after_body' ); ?>
+```
 
 ## Data Layer
 
-GTM offers a dataLayer which allows you pass arbitrary data that can be used to modify which tags are added to your site.
+GTM offers a `dataLayer` which allows you pass arbitrary data that can be used to modify which tags are added to your site.
 
-hm-gtm adds some default options and provides a simple filter for adding in custom key/value pairs.
+This plugin adds some default information such as page author, tags and categories and provides a simple filter for adding in your own custom key/value pairs.
 
 ```php
 <?php
@@ -24,3 +33,5 @@ add_filter( 'hm_gtm_data_layer', function( $data ) {
 
 ?>
 ```
+
+Find out more about [using the `dataLayer` variable here](https://developers.google.com/tag-manager/devguide#datalayer).

--- a/class-plugin.php
+++ b/class-plugin.php
@@ -153,10 +153,24 @@ class Plugin {
 			$data['network'] = network_home_url();
 		}
 
+		/**
+		 * Filter the intial dataLayer variable data.
+		 *
+		 * @param array $data
+		 */
 		$data = apply_filters( 'hm_gtm_data_layer', $data );
+		
+		/**
+		 * Filter the dataLayer variable name. Tag manager allow for 
+		 * custom variable names to avoid collisions and scope container events.
+		 *
+		 * @param string $data_layer The name to use for the dataLayer variable.
+		 */
+		$data_layer_var = apply_filters( 'hm_gtm_data_layer_var', 'dataLayer' );
 
 		if ( ! empty( $data ) ) {
-			return sprintf( '<script>var dataLayer = %s;</script>',
+			return sprintf( '<script>var %s = %s;</script>',
+				sanitize_key( $data_layer_var ),
 				wp_json_encode( array( $data ) )
 			);
 		}

--- a/hm-gtm.php
+++ b/hm-gtm.php
@@ -13,6 +13,7 @@ namespace HM_GTM;
 require_once __DIR__ . '/class-plugin.php';
 
 add_action( 'plugins_loaded', array( 'HM_GTM\Plugin', 'get_instance' ) );
+add_action( 'wp_head', __NAMESPACE__ . '\tag', 1, 0 );
 
 /**
  * Output the gtm tag, place this immediately after the opening <body> tag
@@ -27,10 +28,10 @@ function tag( $echo = true ) {
 
 	$tag = '
 			<!-- Google Tag Manager -->
-			<noscript><iframe src="//www.googletagmanager.com/ns.html?id=%1$s" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-			<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({\'gtm.start\': new Date().getTime(),event:\'gtm.js\'});
-				var f=d.getElementsByTagName(s)[0], j=d.createElement(s), dl=l!=\'dataLayer\'?\'&l=\'+l:\'\';
-				j.async=true;j.src=\'//www.googletagmanager.com/gtm.js?id=\'+i+dl;f.parentNode.insertBefore(j,f);
+			<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({\'gtm.start\':
+			new Date().getTime(),event:\'gtm.js\'});var f=d.getElementsByTagName(s)[0],
+			j=d.createElement(s),dl=l!=\'dataLayer\'?\'&l=\'+l:\'\';j.async=true;j.src=
+			\'https://www.googletagmanager.com/gtm.js?id=\'+i+dl;f.parentNode.insertBefore(j,f);
 			})(window,document,\'script\',\'dataLayer\',\'%1$s\');</script>
 			<!-- End Google Tag Manager -->
 			';

--- a/hm-gtm.php
+++ b/hm-gtm.php
@@ -2,10 +2,10 @@
 
 /*
 Plugin Name: Google Tag Manager tools
-Description: Provides basic GTM integration by providing a template tag <code>HM_GTM\tag()</code> to place after <code>&lt;body&gt;</code> and a filterable dataLayer object
+Description: Provides GTM integration per site or for an entire multisite network.
 Author: Human Made Limited
-Version: 1.0.1
-Author URI: http://hmn.md
+Version: 1.1.0
+Author URI: https://humanmade.com
 */
 
 namespace HM_GTM;
@@ -14,49 +14,58 @@ require_once __DIR__ . '/class-plugin.php';
 
 add_action( 'plugins_loaded', array( 'HM_GTM\Plugin', 'get_instance' ) );
 add_action( 'wp_head', __NAMESPACE__ . '\tag', 1, 0 );
+add_action( 'after_body', __NAMESPACE__ . '\tag', 1, 0 );
 
 /**
- * Output the gtm tag, place this immediately after the opening <body> tag
- *
- * @param bool $echo
+ * Outputs the gtm tag, place this immediately after the opening <body> tag
  *
  * @return string
  */
-function tag( $echo = true ) {
-	// Back compat for tag calls in the body of a theme.
-	if ( ! doing_action( 'wp_head' ) ) {
-		return '';
-	}
-
+function tag() {
 	$output = '';
+	
+	/**
+	 * Filter the dataLayer variable name. Tag manager allow for 
+	 * custom variable names to avoid collisions and scope container events.
+	 *
+	 * @param string $data_layer The name to use for the dataLayer variable.
+	 */
+	$data_layer_var = apply_filters( 'hm_gtm_data_layer_var', 'dataLayer' );
 
-	$tag = '
+	if ( doing_action( 'wp_head' ) ) {	
+		// If it's the head action output the JS and dataLayer.
+		$output .= Plugin::data_layer();
+		$tag    = '
 			<!-- Google Tag Manager -->
 			<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({\'gtm.start\':
 			new Date().getTime(),event:\'gtm.js\'});var f=d.getElementsByTagName(s)[0],
 			j=d.createElement(s),dl=l!=\'dataLayer\'?\'&l=\'+l:\'\';j.async=true;j.src=
 			\'https://www.googletagmanager.com/gtm.js?id=\'+i+dl;f.parentNode.insertBefore(j,f);
-			})(window,document,\'script\',\'dataLayer\',\'%1$s\');</script>
+			})(window,document,\'script\',\'%2$s\',\'%1$s\');</script>
 			<!-- End Google Tag Manager -->
 			';
-
-	echo Plugin::data_layer();
+	} else {
+		// If the tag is called directly or on another action output the noscript fallback.
+		// This gives us back compat and noscript support in one go.
+		$tag = '
+			<!-- Google Tag Manager (noscript) -->
+			<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=%1$s"
+			height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+			<!-- End Google Tag Manager (noscript) -->
+			';
+	}
 
 	$id = get_option( 'hm_gtm_id', false );
 	if ( $id ) {
-		$output .= sprintf( $tag, esc_attr( $id ) );
+		$output .= sprintf( $tag, esc_attr( $id ), sanitize_key( $data_layer_var ) );
 	}
 
 	if ( is_multisite() ) {
 		$network_id = get_site_option( 'hm_gtm_network_id' );
 		if ( $network_id ) {
-			$output .= sprintf( $tag, esc_attr( $network_id ) );
+			$output .= sprintf( $tag, esc_attr( $network_id ), sanitize_key( $data_layer_var ) );
 		}
 	}
 
-	if ( $echo ) {
-		echo $output;
-	}
-
-	return $output;
+	echo $output;
 }

--- a/hm-gtm.php
+++ b/hm-gtm.php
@@ -4,7 +4,7 @@
 Plugin Name: Google Tag Manager tools
 Description: Provides basic GTM integration by providing a template tag <code>HM_GTM\tag()</code> to place after <code>&lt;body&gt;</code> and a filterable dataLayer object
 Author: Human Made Limited
-Version: 1.0
+Version: 1.0.1
 Author URI: http://hmn.md
 */
 
@@ -23,6 +23,10 @@ add_action( 'wp_head', __NAMESPACE__ . '\tag', 1, 0 );
  * @return string
  */
 function tag( $echo = true ) {
+	// Back compat for tag calls in the body of a theme.
+	if ( ! doing_action( 'wp_head' ) ) {
+		return '';
+	}
 
 	$output = '';
 


### PR DESCRIPTION
Tag manager no longer needs to be after the opening `<body>` tag and go into the head. This simplifies things a lot as the plugin can just be activated.