### PR TITLE
Don't use plugin_data for getting version

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -191,8 +191,7 @@ function text_settings_field( array $args ) {
  * Enqueue data attribute tracking script.
  */
 function enqueue_scripts() {
-	$plugin_data = get_plugin_data( dirname( __DIR__ ) . '/plugin.php' );
-	wp_enqueue_script( 'hm-gtm', plugins_url( '/assets/events.js', dirname( __FILE__ ) ), [], $plugin_data['Version'], true );
+	wp_enqueue_script( 'hm-gtm', plugins_url( '/assets/events.js', dirname( __FILE__ ) ), [], '2.0.2', true );
 }
 
 /**


### PR DESCRIPTION
The function is an admin function so shouldn't be used in this context.

Fixes #16 