### PR TITLE
Remove erroneous wp_slash call

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -21,7 +21,7 @@ function get_gtm_tag( string $container_id, array $data_layer = [], string $data
 		$tag .= sprintf(
 			'<script>var %1$s = [ %2$s ];</script>',
 			$data_layer_var,
-			wp_json_encode( wp_slash( $data_layer ) )
+			wp_json_encode( $data_layer )
 		);
 	}
 


### PR DESCRIPTION
It's unclear why this code existed, however wp_slash should not be used in this context.