### PR TITLE
Get user properties directly for author pages

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -199,8 +199,8 @@ function get_gtm_data_layer() {
 
 			$data['subtype'] = 'author';
 			$data['author']  = [
-				'slug' => $user->get( 'user_nicename' ),
-				'name' => $user->get( 'display_name' ),
+				'slug' => $user->user_nicename,
+				'name' => $user->display_name,
 			];
 		}
 	}


### PR DESCRIPTION
Calling `WP_User::get()` to retrieve user nicename and display name for author pages seems a bit non-standard, as that's just a wrapper around the magic getter anyways.

```
	/**
	 * Retrieve the value of a property or meta key.
	 *
	 * Retrieves from the users and usermeta table.
	 *
	 * @since 3.3.0
	 *
	 * @param string $key Property
	 * @return mixed
	 */
	public function get( $key ) {
		return $this->__get( $key );
	}
``` 

I've found this code causes fatals when integrating HM-GTM with plugins like [Bylines](https://github.com/humanmade/bylines) which override `get_queried_object()` on author pages to use a different storage object for "authors" - but don't provide a `get()` method on that object.

Accessing the nicename and display name properties directly (and letting the object's getter methods handle the implementation, as is being done with other objects in this function) seems like a more standard way of doing this.

Thoughts?