### PR TITLE
Add aria-describedby and Core CSS classes to text input field

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -180,10 +180,10 @@ function text_settings_field( array $args ) {
 		'description' => '',
 	 ] );
 
-	printf( '<input type="text" id="%1$s" name="%1$s" value="%2$s" />%3$s',
+	printf( '<input type="text" id="%1$s" name="%1$s" value="%2$s" aria-describedby="%1$s-description" class="regular-text ltr" /><p class="description" id="%1$s-description">%3$s</p>',
 		esc_attr( $args['name'] ),
 		esc_attr( $args['value'] ),
-		$args['description'] ? '<br /> <span class="description">' . esc_html( $args['description'] ) . '</span>' : ''
+		esc_html( $args['description'] )
 	);
 }
 


### PR DESCRIPTION
Hi there. 

I recently used this repo to build a plugin of my own and noticed the text input field markup was not the same as Core in regards to the `<p>` description and the `aria-describedby` that is referenced by the input field. This also adds the `regular-text` and `ltr` CSS classes for the input field so it matches other fields on the general options page.

Thanks for making these repos public. Lots of great ideas to learn from.