### PR TITLE
Update register_setting third parameter to be array

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -127,12 +127,12 @@ function add_site_settings() {
 	register_setting( 
 		'general', 
 		'hm_gtm_id',
-		array(
-			'type'              => 'string',
-			'description'       => esc_html__( 'Google Tag Manager Container ID', 'hm_gtm' ),
+		[
+			'type' => 'string',
+			'description' => esc_html__( 'Google Tag Manager Container ID', 'hm_gtm' ),
 			'sanitize_callback' => 'sanitize_text_field',
-			'default'           => '',
-		)
+			'default' => '',
+		]
 	);
 }
 

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -124,7 +124,16 @@ function add_site_settings() {
 		]
 	);
 
-	register_setting( 'general', 'hm_gtm_id', 'sanitize_text_field' );
+	register_setting( 
+		'general', 
+		'hm_gtm_id',
+		array(
+			'type'              => 'string',
+			'description'       => esc_html__( 'Google Tag Manager Container ID', 'hm_gtm' ),
+			'sanitize_callback' => 'sanitize_text_field',
+			'default'           => '',
+		)
+	);
 }
 
 /**


### PR DESCRIPTION
Me again. This is another one I found by using PHPStan. Swapping out the third parameter of the `register_setting` function to use an array instead of a string. Hope it's helpful.

https://developer.wordpress.org/reference/functions/register_setting/#parameters