### PR TITLE
Fix fatal error when accessing non exist user value

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -133,21 +133,23 @@ function get_gtm_data_layer() {
 	if ( is_singular() ) {
 		$post = get_queried_object();
 
-		$data['type'] = 'post';
+		$data['type']    = 'post';
 		$data['subtype'] = $post->post_type;
-		$data['post'] = [
-			'ID' => $post->ID,
-			'slug' => $post->post_name,
+		$data['post']    = [
+			'ID'        => $post->ID,
+			'slug'      => $post->post_name,
 			'published' => $post->post_date_gmt,
-			'modified' => $post->post_modified_gmt,
-			'comments' => get_comment_count( $post->ID )['approved'],
-			'template' => get_page_template_slug( $post->ID ),
+			'modified'  => $post->post_modified_gmt,
+			'comments'  => get_comment_count( $post->ID )['approved'],
+			'template'  => get_page_template_slug( $post->ID ),
 			'thumbnail' => get_the_post_thumbnail_url( $post->ID, 'full' ),
 		];
 
 		if ( post_type_supports( $post->post_type, 'author' ) ) {
-			$data['post']['author_ID'] = $post->post_author;
-			$data['post']['author_slug'] = get_user_by( 'id', $post->post_author )->get( 'user_nicename' );
+			$user = get_user_by( 'id', $post->post_author );
+
+			$data['post']['author_ID']   = $post->post_author;
+			$data['post']['author_slug'] = is_a( $user, 'WP_User' ) ? $user->get( 'user_nicename' ) : '';
 		}
 
 		foreach ( get_object_taxonomies( $post->post_type, 'objects' ) as $taxonomy ) {

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -133,15 +133,15 @@ function get_gtm_data_layer() {
 	if ( is_singular() ) {
 		$post = get_queried_object();
 
-		$data['type']    = 'post';
+		$data['type'] = 'post';
 		$data['subtype'] = $post->post_type;
-		$data['post']    = [
-			'ID'        => $post->ID,
-			'slug'      => $post->post_name,
+		$data['post'] = [
+			'ID' => $post->ID,
+			'slug' => $post->post_name,
 			'published' => $post->post_date_gmt,
-			'modified'  => $post->post_modified_gmt,
-			'comments'  => get_comment_count( $post->ID )['approved'],
-			'template'  => get_page_template_slug( $post->ID ),
+			'modified' => $post->post_modified_gmt,
+			'comments' => get_comment_count( $post->ID )['approved'],
+			'template' => get_page_template_slug( $post->ID ),
 			'thumbnail' => get_the_post_thumbnail_url( $post->ID, 'full' ),
 		];
 

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -149,7 +149,7 @@ function get_gtm_data_layer() {
 			$user = get_user_by( 'id', $post->post_author );
 
 			if ( is_a( $user, 'WP_User' ) ) {
-				$data['post']['author_ID']   = $user->ID;
+				$data['post']['author_ID'] = $user->ID;
 				$data['post']['author_slug'] = $user->user_nicename;
 			}
 		}

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -148,8 +148,10 @@ function get_gtm_data_layer() {
 		if ( post_type_supports( $post->post_type, 'author' ) ) {
 			$user = get_user_by( 'id', $post->post_author );
 
-			$data['post']['author_ID']   = $post->post_author;
-			$data['post']['author_slug'] = is_a( $user, 'WP_User' ) ? $user->get( 'user_nicename' ) : '';
+			if ( is_a( $user, 'WP_User' ) ) {
+				$data['post']['author_ID']   = $user->ID;
+				$data['post']['author_slug'] = $user->user_nicename;
+			}
 		}
 
 		foreach ( get_object_taxonomies( $post->post_type, 'objects' ) as $taxonomy ) {


### PR DESCRIPTION
This PR fixed fatal error thrown when using `get_user_by()` function which could return false.

Error log:
```
[25-Jan-2021 09:53:34 UTC] PHP Fatal error:  Uncaught Error: Call to a member function get() on boolean in /usr/src/app/vendor/humanmade/hm-gtm/inc/template-tags.php:150
Stack trace:
#0 /usr/src/app/vendor/humanmade/hm-gtm/inc/namespace.php(86): get_gtm_data_layer()
#1 /usr/src/app/wordpress/wp-includes/class-wp-hook.php(285): HM\GTM\output_tag()
#2 /usr/src/app/wordpress/wp-includes/class-wp-hook.php(311): WP_Hook->apply_filters(NULL, Array)
#3 /usr/src/app/wordpress/wp-includes/plugin.php(478): WP_Hook->do_action(Array)
#4 /usr/src/app/wordpress/wp-includes/general-template.php(2884): do_action('wp_head')
#5 /usr/src/app/content/themes/standard-chartered-non-retail/header.php(20): wp_head()
#6 /usr/src/app/wordpress/wp-includes/template.php(723): require_once('/usr/src/app/co...')
#7 /usr/src/app/wordpress/wp-includes/template.php(672): load_template('/usr/src/app/co...', true)
#8 /usr/src/app/wordpress/wp-includes/general-template.php(41): locate_template(Array, true)
#9 /usr/src/app/content/themes/standard-chartered-non-retail/singular.php(8): get_header()
#10 /usr/src/app/wordpress/wp-includes/template-loader.php(106): include('/usr/src/app/co...')
#11 /usr/src/app/wordpress/wp-blog-header.php(19): require_once('/usr/src/app/wo...')
#12 /usr/src/app/index.php(21): require('/usr/src/app/wo...')
#13 {main}
thrown in /usr/src/app/vendor/humanmade/hm-gtm/inc/template-tags.php on line 150
```