### PR TITLE
Check for existing window.dataLayer, append if found.

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -18,11 +18,8 @@ function get_gtm_tag( string $container_id, array $data_layer = [], string $data
 	$data_layer_var = preg_replace( '/[^a-z0-9_\-]/i', '', $data_layer_var );
 
 	if ( ! empty( $data_layer ) ) {
-		$tag .= sprintf('
-			<script>
-			window.%1$s = window.%1$s || [];
-			window.%1$s.push([ %2$s ]);
-			</script>',
+		$tag .= sprintf(
+			'<script>window.%1$s = window.%1$s || []; window.%1$s.push([ %2$s ]);</script>',
 			$data_layer_var,
 			wp_json_encode( $data_layer )
 		);


### PR DESCRIPTION
I've run into an issue when putting in place a cookie/script management solution, which needs to manage the `dataLayer` variable earlier than gtm.

The current version will always overwrite an existing `dataLayer` rather than appending/mutating it:

```html
<script> var dataLayer = [ "lorem": "ipsum" ] </script>
```

I've added an updated version in line with the current documentation at https://developers.google.com/tag-platform/tag-manager/web/datalayer, which will produce the following:

```html
<script>
   window.dataLayer = window.dataLayer || [];
   window.dataLayer.push ( [ "lorem": "ipsum" ] );
</script>
```

At present this is the default, with an option to use the current replacer version dependent on a filter, but if preferred then this could be reversed.

To avoid too much nesting in the `get_gtm_tag` function I've split this logic out into its own function, but if preferred this could stay within the same function.
