### PR TITLE
Fix incorrect data type for first data layer object

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -19,7 +19,7 @@ function get_gtm_tag( string $container_id, array $data_layer = [], string $data
 
 	if ( ! empty( $data_layer ) ) {
 		$tag .= sprintf(
-			'<script>window.%1$s = window.%1$s || []; window.%1$s.push([ %2$s ]);</script>',
+			'<script>window.%1$s = window.%1$s || []; window.%1$s.push( %2$s );</script>',
 			$data_layer_var,
 			wp_json_encode( $data_layer )
 		);


### PR DESCRIPTION
For the first data layer, we should push a key-value object, not an array. 
Read more: https://developers.google.com/tag-platform/tag-manager/web/datalayer#one_push_multiple_variables

This PR will fix this data type error.

Before:
![ScreenCapture - 2022-07-18 at 18 46 47](https://user-images.githubusercontent.com/656006/179504745-152a06f8-4537-4015-9207-8a1e1c2519cc.jpg)

After:
![ScreenCapture - 2022-07-18 at 18 48 12](https://user-images.githubusercontent.com/656006/179504998-b291e183-8965-4394-abed-98b9ade8a131.jpg)

