### PR TITLE
Fix #35: Don't allow dashes in the datalayer variable names

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -15,7 +15,7 @@
  */
 function get_gtm_tag( string $container_id, array $data_layer = [], string $data_layer_var = 'dataLayer' ) : string {
 	$tag = '';
-	$data_layer_var = preg_replace( '/[^a-z0-9_\-]/i', '', $data_layer_var );
+	$data_layer_var = preg_replace( '/[^a-z0-9_]/i', '', $data_layer_var );
 
 	if ( ! empty( $data_layer ) ) {
 		$tag .= sprintf(


### PR DESCRIPTION
Fixes #35 by removing dashes from the allowed data layer variable name characters