### PR TITLE
Add support for setting GTM events via editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,23 @@ You can explore and view the `dataLayer` variables by previewing your container 
 
 ### Custom event tracking
 
+In the block editor you can add event tracking to any block via the settings panel in the block sidebar. This calls `dataLayer.push()` with the event data specified.
+
+All blocks are opted in to support this by default, but you can set block support to false with the following during block registration, or via `block.json`. For example:
+
+```php
+register_block_type( 'my-plugin/my-block', [
+  'supports' => [
+    'gtm' => false,
+  ],
+) );
+```
+
 By default the plugin will look for elements with special data attributes in your markup and listen to the specified event to push events to the data layer.
 
 The data attributes are:
 
-- `data-gtm-on`: _enum_ [click|submit|keyup|focus|blur] The JS event to listen for, defaults to 'click'.
+- `data-gtm-on`: _enum_ [click|submit|keyup|focusin|focusout|mouseenter|mouseleave] The JS event to listen for, defaults to 'click'.
 - `data-gtm-event`: _string_ The name or action of the event eg. "play".
 - `data-gtm-category`: _string_ Optional group the event belongs to.
 - `data-gtm-label`: _string_ Optional human readable label for the event.

--- a/assets/blocks.js
+++ b/assets/blocks.js
@@ -1,5 +1,6 @@
 const addFilter = wp.hooks.addFilter;
 const InspectorControls = wp.blockEditor.InspectorControls;
+const hasBlockSupport = wp.blocks.hasBlockSupport;
 const TextControl = wp.components.TextControl;
 const SelectControl = wp.components.SelectControl;
 const PanelBody = wp.components.PanelBody;
@@ -50,6 +51,7 @@ function HMGTMEvents(BlockEdit) {
 									{ label: __( 'Submit', 'hm-gtm' ), value: 'submit' },
 									{ label: __( 'Focus', 'hm-gtm' ), value: 'focusin' },
 									{ label: __( 'Blur', 'hm-gtm' ), value: 'focusout' },
+									{ label: __( 'Key up', 'hm-gtm' ), value: 'keyup' },
 									{ label: __( 'Mouseover', 'hm-gtm' ), value: 'mouseenter' },
 									{ label: __( 'Mouseout', 'hm-gtm' ), value: 'mouseleave' }
 								],
@@ -118,20 +120,17 @@ function HMGTMEvents(BlockEdit) {
 addFilter(
 	'editor.BlockEdit',
 	'hm-gtm/events',
-	HMGTMEvents
+	HMGTMEvents,
+	5000
 );
 
 function addGTMAttribute(settings) {
-	if ( settings.supports?.gtm === false ) {
+	if ( ! hasBlockSupport( settings.name, 'gtm', true ) ) {
 		return settings;
 	}
 
 	return {
 		...settings,
-		supports: {
-			...( settings.supports || {} ),
-			gtm: true,
-		},
 		attributes: {
 			...settings.attributes,
 			gtm: {
@@ -140,7 +139,7 @@ function addGTMAttribute(settings) {
 				properties: {
 					trigger: {
 						type: 'string',
-						enum: [ 'click', 'submit', 'focusin', 'focusout', 'mouseenter', 'mouseleave' ]
+						enum: [ 'click', 'submit', 'focusin', 'focusout', 'keyup', 'mouseenter', 'mouseleave' ]
 					},
 					event: {
 						type: 'string'
@@ -166,5 +165,6 @@ function addGTMAttribute(settings) {
 wp.hooks.addFilter(
 	'blocks.registerBlockType',
 	'hm-gtm/add-gtm-attribute',
-	addGTMAttribute
+	addGTMAttribute,
+	5000
 );

--- a/assets/blocks.js
+++ b/assets/blocks.js
@@ -1,0 +1,170 @@
+const addFilter = wp.hooks.addFilter;
+const InspectorControls = wp.blockEditor.InspectorControls;
+const TextControl = wp.components.TextControl;
+const SelectControl = wp.components.SelectControl;
+const PanelBody = wp.components.PanelBody;
+const __ = wp.i18n.__;
+
+function HMGTMEvents(BlockEdit) {
+	return function (props) {
+		const attributes = props.attributes;
+		const setAttributes = props.setAttributes;
+
+		const supportsGTM = attributes?.gtm !== undefined;
+
+		// Check if the block supports "gtm"
+		if (!supportsGTM) {
+			return wp.element.createElement(BlockEdit, props);
+		}
+
+		function update( settings ) {
+			setAttributes({ gtm: { ...(attributes.gtm || {}), ...settings } });
+		}
+
+		return (
+			wp.element.createElement(
+				wp.element.Fragment,
+				null,
+				wp.element.createElement(
+					BlockEdit,
+					props
+				),
+				wp.element.createElement(
+					InspectorControls,
+					null,
+					wp.element.createElement(
+						PanelBody,
+						{ title: __( 'Google Tag Manager', 'hm-gtm' ), initialOpen: false },
+						wp.element.createElement(
+							'p',
+							{},
+							__( 'The following options allow you to push an event to GTM when this block is interacted with.', 'hm-gtm' )
+						),
+						wp.element.createElement(
+							SelectControl,
+							{
+								label: __( 'Event Trigger', 'hm-gtm' ),
+								value: attributes?.gtm?.trigger || 'click',
+								options: [
+									{ label: __( 'Click', 'hm-gtm' ), value: 'click' },
+									{ label: __( 'Submit', 'hm-gtm' ), value: 'submit' },
+									{ label: __( 'Focus', 'hm-gtm' ), value: 'focusin' },
+									{ label: __( 'Blur', 'hm-gtm' ), value: 'focusout' },
+									{ label: __( 'Mouseover', 'hm-gtm' ), value: 'mouseenter' },
+									{ label: __( 'Mouseout', 'hm-gtm' ), value: 'mouseleave' }
+								],
+								onChange: function (value) {
+									update({ trigger: value });
+								}
+							}
+						),
+						wp.element.createElement(
+							TextControl,
+							{
+								label: __( 'Event Name', 'hm-gtm' ),
+								value: attributes.gtm?.event || '',
+								onChange: function (value) {
+									update({ event: value });
+								}
+							}
+						),
+						wp.element.createElement(
+							TextControl,
+							{
+								label: __( 'Action', 'hm-gtm' ),
+								value: attributes.gtm?.action || '',
+								onChange: function (value) {
+									update({ action: value });
+								}
+							}
+						),
+						wp.element.createElement(
+							TextControl,
+							{
+								label: __( 'Category', 'hm-gtm' ),
+								value: attributes.gtm?.category || '',
+								onChange: function (value) {
+									update({ category: value });
+								}
+							}
+						),
+						wp.element.createElement(
+							TextControl,
+							{
+								label: __( 'Label', 'hm-gtm' ),
+								value: attributes.gtm?.label || '',
+								onChange: function (value) {
+									update({ label: value });
+								}
+							}
+						),
+						wp.element.createElement(
+							TextControl,
+							{
+								label: __( 'Value', 'hm-gtm' ),
+								value: attributes.gtm?.value || '',
+								onChange: function (value) {
+									update({ value: value });
+								}
+							}
+						)
+					)
+				)
+			)
+		);
+	};
+}
+
+addFilter(
+	'editor.BlockEdit',
+	'hm-gtm/events',
+	HMGTMEvents
+);
+
+function addGTMAttribute(settings) {
+	if ( settings.supports?.gtm === false ) {
+		return settings;
+	}
+
+	return {
+		...settings,
+		supports: {
+			...( settings.supports || {} ),
+			gtm: true,
+		},
+		attributes: {
+			...settings.attributes,
+			gtm: {
+				type: 'object',
+				default: {},
+				properties: {
+					trigger: {
+						type: 'string',
+						enum: [ 'click', 'submit', 'focusin', 'focusout', 'mouseenter', 'mouseleave' ]
+					},
+					event: {
+						type: 'string'
+					},
+					action: {
+						type: 'string'
+					},
+					category: {
+						type: 'string'
+					},
+					label: {
+						type: 'string'
+					},
+					value: {
+						type: 'string'
+					}
+				}
+			},
+		},
+	};
+}
+
+wp.hooks.addFilter(
+	'blocks.registerBlockType',
+	'hm-gtm/add-gtm-attribute',
+	addGTMAttribute
+);

--- a/plugin.php
+++ b/plugin.php
@@ -3,13 +3,13 @@
  * Plugin Name: Google Tag Manager tools
  * Description: Provides GTM integration per site or for an entire multisite network.
  * Author: Human Made Limited
- * Version: 3.0.0
+ * Version: 3.1.0
  * Author URI: https://humanmade.com
  */
 
 namespace HM\GTM;
 
-const VERSION = '3.0.0';
+const VERSION = '3.1.0';
 
 require_once __DIR__ . '/inc/namespace.php';
 require_once __DIR__ . '/inc/template-tags.php';


### PR DESCRIPTION
Adds a panel to block settings for pushing a tag manager event to all blocks. I tried using the block supports API but its still a bit too unreliable.