### PR TITLE
Strip www. in 1st party cookie restore feature

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -536,7 +536,7 @@ function uuid_cookie_endpoint() : void {
 				setcookie( $cookie_name, $cookie_value, [
 					'expires' => time() + ( YEAR_IN_SECONDS * 2 ),
 					'path'     => '/',
-					'domain'   => '.' . wp_parse_url( home_url(), PHP_URL_HOST ),
+					'domain'   => '.' . str_replace( 'www.', '', wp_parse_url( home_url(), PHP_URL_HOST ) ),
 					'secure'   => true,
 					'httponly' => false,
 					'samesite' => 'lax',


### PR DESCRIPTION
Fixes #44

`www.` is a special case so we can target this directly. We should avoid stripping other subdomains as they may be intentional e.g. `subsite.primary.com`.

There may be nuances to this on a subdomain multisite install for instance though, so a further enhancement would be to add a filter or setting for this, but this will be good for 90% of use cases for now and separates out the bug fix from the enhancement.