### PR TITLE
Fix fatal page loading after assigning event name

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -600,7 +600,8 @@ function filter_render_block( string $block_content, array $block ) : string {
 		}
 	}
 
-	$block = new WP_HTML_Tag_Processor( $block_content );
+	$block = new WP_HTML_Tag_Processor( trim( $block_content ) );
+	$block->next_tag();
 	$block->set_bookmark( 'root' );
 
 	$query = null;


### PR DESCRIPTION
Fixes #47.

Problem: Viewing or editing a page fatals. When creating an empty page with a button, selecting the button, and adding an event name in the sidebar, then saving the page.

Calling WP_HTML_Tag_Processor::set_bookmark('root') immediately after construction can pass null token positions to WP_HTML_Span::__construct(), causing a fatal TypeError: Argument #1 ($start) must be of type int, null given.

This is worked around by calling `next_tag()` first.