### PR TITLE
Add phpcs:ignores to pass security review

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -407,6 +407,7 @@ function add_network_settings() {
  * Save Network Settings for Google Tag Manager.
  */
 function save_network_settings() {
+	// phpcs:disable HM.Security.NonceVerification.Missing -- Hooked to update_wpmu_options, which WP core only fires from wp-admin/network/settings.php after check_admin_referer( 'siteoptions' ) has already passed.
 	if ( isset( $_POST['hm_gtm_network_id'] ) ) {
 		update_site_option( 'hm_gtm_network_id', sanitize_text_field( wp_unslash( $_POST['hm_gtm_network_id'] ) ) );
 	}
@@ -419,6 +420,7 @@ function save_network_settings() {
 	if ( isset( $_POST['hm_gtm_network_snippet_iframe'] ) ) {
 		update_site_option( 'hm_gtm_network_snippet_iframe', sanitize_textarea_field( wp_unslash( $_POST['hm_gtm_network_snippet_iframe'] ) ) );
 	}
+	// phpcs:enable HM.Security.NonceVerification.Missing
 }
 
 /**
@@ -515,7 +517,7 @@ function uuid_cookie_endpoint() : void {
 					return rest_ensure_response( null );
 				}
 
-				$cookie_value = $_COOKIE[ $cookie_name ] ?? '';
+				$cookie_value = isset( $_COOKIE[ $cookie_name ] ) ? sanitize_text_field( wp_unslash( $_COOKIE[ $cookie_name ] ) ) : '';
 
 				// Generate or get param from localStorage if defined.
 				if ( ! wp_is_uuid( $cookie_value ) ) {

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -79,6 +79,7 @@ function get_gtm_tag( string $container_id, array $data_layer = [], string $data
  * @param string $snippet Optional custom code snippet.
  */
 function gtm_tag( string $container_id, array $data_layer = [], string $data_layer_var = 'dataLayer', string $container_url = '', string $snippet = '' ) {
+	// phpcs:ignore HM.Security.EscapeOutput.OutputNotEscaped -- get_gtm_tag() escapes every dynamic value (esc_js/esc_attr/wp_json_encode) before interpolating into the static script markup.
 	echo get_gtm_tag( ...func_get_args() );
 }
 
@@ -113,6 +114,7 @@ function get_gtm_tag_iframe( string $container_id, string $container_url = '', s
  * @param string $snippet Optional custom code snippet to use.
  */
 function gtm_tag_iframe( string $container_id, string $container_url = '', string $snippet = '' ) {
+	// phpcs:ignore HM.Security.EscapeOutput.OutputNotEscaped -- get_gtm_tag_iframe() escapes every dynamic value (esc_attr) before interpolating into the static iframe markup.
 	echo get_gtm_tag_iframe( ...func_get_args() );
 }
 


### PR DESCRIPTION
This plugin triggers a few warnings when passed through WPCS Security rulesets. Most of these instances are safe - the nonce and referrer checks are handled by core, and the GTM tag output is escaped elsewhere. The only functional change is unslashing and sanitizing of client input in the cookie value, and that seems like a safe change.